### PR TITLE
Use JSON arrays for seeders and initial IP's

### DIFF
--- a/configs/bitcoin-test.json
+++ b/configs/bitcoin-test.json
@@ -6,7 +6,7 @@
  "Pver": 70001,
  "DNSName": "btctseed.zagbot.com",
  "TTL": 300,
- "InitialIP": "0.0.0.0,0.0.0.0",
+ "InitialIPs": ["0.0.0.0","0.0.0.0"],
  "Seeders": [
   "testnet-seed.alexykot.me",
   "testnet-seed.bitcoin.petertodd.org",

--- a/configs/bitcoin-test.json
+++ b/configs/bitcoin-test.json
@@ -7,7 +7,9 @@
  "DNSName": "btctseed.zagbot.com",
  "TTL": 300,
  "InitialIP": "0.0.0.0,0.0.0.0",
- "Seeder1": "testnet-seed.alexykot.me",
- "Seeder2": "testnet-seed.bitcoin.petertodd.org",
- "Seeder3": "testnet-seed.bluematt.me"
+ "Seeders": [
+  "testnet-seed.alexykot.me",
+  "testnet-seed.bitcoin.petertodd.org",
+  "testnet-seed.bluematt.me"
+ ]
 }

--- a/configs/bitcoin-test.json
+++ b/configs/bitcoin-test.json
@@ -9,7 +9,10 @@
  "InitialIPs": ["0.0.0.0","0.0.0.0"],
  "Seeders": [
   "testnet-seed.alexykot.me",
+  "testnet-seed.bitcoin.jonasschnelli.ch",
   "testnet-seed.bitcoin.petertodd.org",
+  "seed.tbtc.petertodd.org",
+  "seed.testnet.bitcoin.sprovoost.nl",
   "testnet-seed.bluematt.me"
  ]
 }

--- a/configs/bitcoin.json
+++ b/configs/bitcoin.json
@@ -8,8 +8,15 @@
  "TTL": 600,
  "InitialIPs": ["0.0.0.0","0.0.0.0"],
  "Seeders": [
+  "seed.bitcoin.sipa.be",
   "dnsseed.bluematt.me",
   "bitseed.xf2.org",
-  "dnsseed.bitcoin.dashjr.org"
+  "dnsseed.bitcoin.dashjr.org",
+  "seed.bitcoinstats.com",
+  "seed.bitcoin.jonasschnelli.ch",
+  "seed.btc.petertodd.org",
+  "seed.bitcoin.sprovoost.nl",
+  "dnsseed.emzy.de",
+  "seed.bitcoin.wiz.biz"
  ]
 }

--- a/configs/bitcoin.json
+++ b/configs/bitcoin.json
@@ -7,7 +7,9 @@
  "DNSName": "btcseed.zagbot.com",
  "TTL": 600,
  "InitialIP": "0.0.0.0,0.0.0.0",
- "Seeder1": "dnsseed.bluematt.me",
- "Seeder2": "bitseed.xf2.org",
- "Seeder3": "dnsseed.bitcoin.dashjr.org"
+ "Seeders": [
+  "dnsseed.bluematt.me",
+  "bitseed.xf2.org",
+  "dnsseed.bitcoin.dashjr.org"
+ ]
 }

--- a/configs/bitcoin.json
+++ b/configs/bitcoin.json
@@ -6,7 +6,7 @@
  "Pver": 70001,
  "DNSName": "btcseed.zagbot.com",
  "TTL": 600,
- "InitialIP": "0.0.0.0,0.0.0.0",
+ "InitialIPs": ["0.0.0.0","0.0.0.0"],
  "Seeders": [
   "dnsseed.bluematt.me",
   "bitseed.xf2.org",

--- a/configs/dnsseeder.json
+++ b/configs/dnsseeder.json
@@ -7,7 +7,9 @@
  "DNSName": "seeder.example.com",
  "TTL": 600,
  "InitialIP": "0.0.0.0,0.0.0.0",
- "Seeder1": "seeder1.example.com",
- "Seeder2": "seed1.bob.com",
- "Seeder3": "seed2.example.com"
+ "Seeders": [
+  "seeder1.example.com",
+  "seed1.bob.com",
+  "seed2.example.com"
+ ]
 }

--- a/configs/dnsseeder.json
+++ b/configs/dnsseeder.json
@@ -6,7 +6,7 @@
  "Pver": 70001,
  "DNSName": "seeder.example.com",
  "TTL": 600,
- "InitialIP": "0.0.0.0,0.0.0.0",
+ "InitialIPs": ["0.0.0.0","0.0.0.0"],
  "Seeders": [
   "seeder1.example.com",
   "seed1.bob.com",

--- a/configs/namecoin.json
+++ b/configs/namecoin.json
@@ -6,7 +6,7 @@
  "Pver": 70001,
  "DNSName": "dnsseed.nmctest.net",
  "TTL": 600,
- "InitialIP": "0.0.0.0,0.0.0.0",
+ "InitialIPs": ["0.0.0.0","0.0.0.0"],
  "Seeders": [
   "nmc.seed.quisquis.de",
   "seed.nmc.markasoftware.com"

--- a/configs/namecoin.json
+++ b/configs/namecoin.json
@@ -7,6 +7,8 @@
  "DNSName": "dnsseed.nmctest.net",
  "TTL": 600,
  "InitialIP": "0.0.0.0,0.0.0.0",
- "Seeder1": "nmc.seed.quisquis.de",
- "Seeder2": "seed.nmc.markasoftware.com"
+ "Seeders": [
+  "nmc.seed.quisquis.de",
+  "seed.nmc.markasoftware.com"
+ ]
 }

--- a/configs/namecoin.json
+++ b/configs/namecoin.json
@@ -12,6 +12,7 @@
   "seed.nmc.markasoftware.com",
   "seed.namecoin.libreisp.se",
   "dnsseed1.nmc.dotbit.zone",
-  "dnsseed2.nmc.dotbit.zone"
+  "dnsseed2.nmc.dotbit.zone",
+  "dnsseed.nmc.testls.space"
  ]
 }

--- a/configs/namecoin.json
+++ b/configs/namecoin.json
@@ -9,6 +9,9 @@
  "InitialIPs": ["0.0.0.0","0.0.0.0"],
  "Seeders": [
   "nmc.seed.quisquis.de",
-  "seed.nmc.markasoftware.com"
+  "seed.nmc.markasoftware.com",
+  "seed.namecoin.libreisp.se",
+  "dnsseed1.nmc.dotbit.zone",
+  "dnsseed2.nmc.dotbit.zone"
  ]
 }

--- a/configs/twister.json
+++ b/configs/twister.json
@@ -7,7 +7,9 @@
  "DNSName": "dnsseed.zagbot.com",
  "TTL": 600,
  "InitialIP": "0.0.0.0,0.0.0.0",
- "Seeder1": "seed2.twister.net.co",
- "Seeder2": "seed.twister.net.co",
- "Seeder3": "seed3.twister.net.co"
+ "Seeders": [
+  "seed2.twister.net.co",
+  "seed.twister.net.co",
+  "seed3.twister.net.co"
+ ]
 }

--- a/configs/twister.json
+++ b/configs/twister.json
@@ -6,7 +6,7 @@
  "Pver": 60000,
  "DNSName": "dnsseed.zagbot.com",
  "TTL": 600,
- "InitialIP": "0.0.0.0,0.0.0.0",
+ "InitialIPs": ["0.0.0.0","0.0.0.0"],
  "Seeders": [
   "seed2.twister.net.co",
   "seed.twister.net.co",

--- a/network.go
+++ b/network.go
@@ -11,15 +11,15 @@ import (
 
 // JNetwork is the exported struct that is read from the network file
 type JNetwork struct {
-	Name      string
-	Desc      string
-	ID        string
-	Port      uint16
-	Pver      uint32
-	DNSName   string
-	TTL       uint32
-	InitialIP string
-	Seeders   []string
+	Name       string
+	Desc       string
+	ID         string
+	Port       uint16
+	Pver       uint32
+	DNSName    string
+	TTL        uint32
+	InitialIPs []string
+	Seeders    []string
 }
 
 func createNetFile() {
@@ -27,15 +27,18 @@ func createNetFile() {
 
 	// create a struct to encode with json
 	jnw := &JNetwork{
-		ID:        "0xabcdef01",
-		Port:      1234,
-		Pver:      70001,
-		TTL:       600,
-		DNSName:   "seeder.example.com",
-		Name:      "SeederNet",
-		Desc:      "Description of SeederNet",
-		InitialIP: "",
-		Seeders:   []string{
+		ID:         "0xabcdef01",
+		Port:       1234,
+		Pver:       70001,
+		TTL:        600,
+		DNSName:    "seeder.example.com",
+		Name:       "SeederNet",
+		Desc:       "Description of SeederNet",
+		InitialIPs: []string{
+			"0.0.0.0",
+			"0.0.0.0",
+		},
+		Seeders:    []string{
 			"seeder1.example.com",
 			"seed1.bob.com",
 			"seed2.example.com",
@@ -104,7 +107,7 @@ func initNetwork(jnw JNetwork) (*dnsseeder, error) {
 	}
 	seeder.id = wire.BitcoinNet(t1)
 
-	seeder.initialIP = jnw.InitialIP
+	seeder.initialIPs = jnw.InitialIPs
 
 	// load the seeder dns
 	seeder.seeders = jnw.Seeders

--- a/network.go
+++ b/network.go
@@ -19,9 +19,7 @@ type JNetwork struct {
 	DNSName   string
 	TTL       uint32
 	InitialIP string
-	Seeder1   string
-	Seeder2   string
-	Seeder3   string
+	Seeders   []string
 }
 
 func createNetFile() {
@@ -37,9 +35,11 @@ func createNetFile() {
 		Name:      "SeederNet",
 		Desc:      "Description of SeederNet",
 		InitialIP: "",
-		Seeder1:   "seeder1.example.com",
-		Seeder2:   "seed1.bob.com",
-		Seeder3:   "seed2.example.com",
+		Seeders:   []string{
+			"seeder1.example.com",
+			"seed1.bob.com",
+			"seed2.example.com",
+		},
 	}
 
 	f, err := os.Create("dnsseeder.json")
@@ -107,10 +107,7 @@ func initNetwork(jnw JNetwork) (*dnsseeder, error) {
 	seeder.initialIP = jnw.InitialIP
 
 	// load the seeder dns
-	seeder.seeders = make([]string, 3)
-	seeder.seeders[0] = jnw.Seeder1
-	seeder.seeders[1] = jnw.Seeder2
-	seeder.seeders[2] = jnw.Seeder3
+	seeder.seeders = jnw.Seeders
 
 	// add some checks to the start & delay values to keep them sane
 	seeder.maxStart = []uint32{20, 20, 20, 30}


### PR DESCRIPTION
More semantically correct, and allows more than 3 seeders per network.

Also add some more seeds for Namecoin, Bitcoin, and Bitcoin Testnet, now that this is technically possible.